### PR TITLE
JetPack 4.4 GA update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG JETPACK_VERSION="r32.4.2"
+ARG JETPACK_VERSION="r32.4.3"
 
 FROM registry.hub.docker.com/mdegans/l4t-base:${JETPACK_VERSION}
 

--- a/build_opencv.sh
+++ b/build_opencv.sh
@@ -151,7 +151,7 @@ configure () {
 
 main () {
 
-    if ! [[ -f "./.dockerenv" ]]; then
+    if [[ ! -f "/.dockerenv" ]]; then
         echo "this script will break your system if run outside docker" 1>&2
         exit 1
     fi

--- a/build_opencv.sh
+++ b/build_opencv.sh
@@ -15,6 +15,7 @@ cleanup () {
     apt-get purge -y --autoremove \
         gosu \
         build-essential \
+        ca-certificates \
         cmake \
         git \
         cuda-compiler-10-2 \
@@ -61,6 +62,11 @@ install_dependencies () {
     # open-cv has a lot of dependencies, but most can be found in the default
     # package repository or should already be installed (eg. CUDA).
     echo "Installing build dependencies."
+    # well, shit, they fixed it, so we do this to get the certs temporarily
+    mv /etc/apt/sources.list.d/nvidia-l4t-apt-source.list /etc/apt/
+    apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates
+    mv /etc/apt/nvidia-l4t-apt-source.list /etc/apt/sources.list.d
     apt-get update && apt-get install -y --no-install-recommends \
         gosu \
         cuda-compiler-10-2 \
@@ -144,6 +150,11 @@ configure () {
 }
 
 main () {
+
+    if ! [[ -f "./.dockerenv" ]]; then
+        echo "this script will break your system if run outside docker" 1>&2
+        exit 1
+    fi
 
     echo "OPENCV_VERSION=${OPENCV_VERSION}"
     echo "OPENCV_DO_TEST=${OPENCV_DO_TEST}"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -3,11 +3,11 @@
 set -ex
 
 # just change these to bump the version
-readonly JETPACK_VERSION="r32.4.2"
+readonly JETPACK_VERSION="r32.4.3"
 readonly OPENCV_VERSION="4.3.0"
 
 # build the image
-docker build \
+docker build --pull \
     --build-arg OPENCV_BUILD_JOBS=$(nproc) \
     --build-arg JETPACK_VERSION=${JETPACK_VERSION} \
     --build-arg OPENCV_VERSION=${OPENCV_VERSION} \

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -4,7 +4,7 @@ set -ex
 
 # just change these to bump the version
 readonly JETPACK_VERSION="r32.4.3"
-readonly OPENCV_VERSION="4.3.0"
+readonly OPENCV_VERSION="master"
 
 # build the image
 docker build --pull \
@@ -12,6 +12,5 @@ docker build --pull \
     --build-arg JETPACK_VERSION=${JETPACK_VERSION} \
     --build-arg OPENCV_VERSION=${OPENCV_VERSION} \
     -t mdegans/tegra-opencv:jp-${JETPACK_VERSION}-cv-${OPENCV_VERSION} \
+    -t mdegans/tegra-opencv:latest \
     . 2>&1 | tee build.log
-# tag it as latest
-docker tag mdegans/tegra-opencv:jp-${JETPACK_VERSION}-cv-${OPENCV_VERSION} mdegans/tegra-opencv:latest


### PR DESCRIPTION
* changes necessary to build under JetPack 4.4 with the new base image.
* tag syntax update (multiple `-t` rather than a separate `docker tag`). This may not work on older docker versions, but this is not applicable to recent JetPacks.